### PR TITLE
feat(usb): disable parkmode for dwc3/xhci usb3.0 host controller

### DIFF
--- a/arch/arm64/boot/dts/hobot/hobot-xj3.dtsi
+++ b/arch/arm64/boot/dts/hobot/hobot-xj3.dtsi
@@ -297,6 +297,7 @@
 				/* snps,dis-u2-entry-quirk; */    /* disable u2 entry */
 				snps,dis_u2_susphy_quirk;
 				/* snps,dis_u3_susphy_quirk; */
+				snps,parkmode-disable-ss-quirk;
 				extcon = <&usb_id>;
 				status = "disabled";
 			};


### PR DESCRIPTION
Summary:

	In certain circumstances, the XHCI SuperSpeed instance in park mode
	can fail to recover, thus on Amlogic G12A/G12B/SM1 SoCs when there is high
	load on the single XHCI SuperSpeed instance, the controller can crash like:
	xhci-hcd xhci-hcd.0.auto: xHCI host not responding to stop endpoint command.
	xhci-hcd xhci-hcd.0.auto: Host halt failed, -110
	xhci-hcd xhci-hcd.0.auto: xHCI host controller not responding, assume dead
	xhci-hcd xhci-hcd.0.auto: xHCI host not responding to stop endpoint command.
	hub 2-1.1:1.0: hub_ext_port_status failed (err = -22)
	xhci-hcd xhci-hcd.0.auto: HC died; cleaning up
	usb 2-1.1-port1: cannot reset (err = -22)

	Setting the PARKMODE_DISABLE_SS bit in the DWC3_USB3_GUCTL1 mitigates
	the issue. The bit is described as :
	"When this bit is set to '1' all SS bus instances in park mode are disabled"

	Synopsys explains:
	The GUCTL1.PARKMODE_DISABLE_SS is only available in
	dwc_usb3 controller running in host mode.
	This should not be set for other IPs.
	This can be disabled by default based on IP, but I recommend to have a
	property to enable this feature for devices that need this.