### PR TITLE
rdk:dtb: Remove the display mode parameter in bootargs in the device …

### DIFF
--- a/arch/arm64/boot/dts/hobot/hobot-x3-cm.dts
+++ b/arch/arm64/boot/dts/hobot/hobot-x3-cm.dts
@@ -85,7 +85,7 @@
 	};
 
 	chosen {
-		bootargs = "earlycon loglevel=8 kgdboc=ttyS0 video=hobot:x3sdb-hdmi ";
+		bootargs = "earlycon loglevel=8 kgdboc=ttyS0 ";
 		stdout-path = "serial0";
 	};
 

--- a/arch/arm64/boot/dts/hobot/hobot-x3-pi.dts
+++ b/arch/arm64/boot/dts/hobot/hobot-x3-pi.dts
@@ -84,7 +84,7 @@
 	};
 
 	chosen {
-		bootargs = "earlycon loglevel=8 kgdboc=ttyS0 video=hobot:x3sdb-hdmi ";
+		bootargs = "earlycon loglevel=8 kgdboc=ttyS0 ";
 		stdout-path = "serial0";
 	};
 

--- a/arch/arm64/boot/dts/hobot/hobot-x3-pi_v2_1.dts
+++ b/arch/arm64/boot/dts/hobot/hobot-x3-pi_v2_1.dts
@@ -84,7 +84,7 @@
 	};
 
 	chosen {
-		bootargs = "earlycon loglevel=8 kgdboc=ttyS0 video=hobot:x3sdb-hdmi ";
+		bootargs = "earlycon loglevel=8 kgdboc=ttyS0 ";
 		stdout-path = "serial0";
 	};
 


### PR DESCRIPTION
…tree

Summary:
    1. Display mode parameter moved to boot.cmd, controlled by user