### PR TITLE
feat:cpufreq: Increase the running frequency of RDK2.1 and MD CPU

### DIFF
--- a/arch/arm64/boot/dts/hobot/hobot-x3-cm.dts
+++ b/arch/arm64/boot/dts/hobot/hobot-x3-cm.dts
@@ -250,6 +250,11 @@
 			opp-hz = /bits/ 64 <1500000000>;
 			opp-microvolt = <990000>;
 			clock-latency-ns = <500000>;
+		};
+		opp06 {
+			opp-hz = /bits/ 64 <1800000000>;
+			opp-microvolt = <990000>;
+			clock-latency-ns = <500000>;
 			turbo-mode;
 		};
 	};

--- a/arch/arm64/boot/dts/hobot/hobot-x3-pi_v2_1.dts
+++ b/arch/arm64/boot/dts/hobot/hobot-x3-pi_v2_1.dts
@@ -249,6 +249,11 @@
 			opp-hz = /bits/ 64 <1500000000>;
 			opp-microvolt = <990000>;
 			clock-latency-ns = <500000>;
+		};
+		opp06 {
+			opp-hz = /bits/ 64 <1800000000>;
+			opp-microvolt = <990000>;
+			clock-latency-ns = <500000>;
 			turbo-mode;
 		};
 	};

--- a/drivers/clk/hobot/cpu-clk-x3.c
+++ b/drivers/clk/hobot/cpu-clk-x3.c
@@ -65,6 +65,7 @@ struct cpu_pll_table pll_table[] = {
 	{1000000000, 1000000000},
 	{1200000000, 1200000000},
 	{1500000000, 1500000000},
+	{1800000000, 1800000000},
 };
 
 static int __set_armpll_clk(struct clk_hw *hw, unsigned long cpu_freq)


### PR DESCRIPTION
Summary:
    1. The maximum frequency of RDK2.1 and MD CPU is 1.5GHz under normal mode
    2. Runs up to 1.8GHz when boost is turned on(RDK2.1 and MD)