### PR TITLE
feat(dtparam): Support modules that can be set by dtparam

### DIFF
--- a/arch/arm64/boot/dts/hobot/hobot-xj3.dtsi
+++ b/arch/arm64/boot/dts/hobot/hobot-xj3.dtsi
@@ -1561,4 +1561,19 @@
 			status = "disabled";
 		};
 	};
+
+	__overrides__ {
+		uart3 = <&uart3>,"status";
+		spi0 = <&spi0>,"status";
+		spi1 = <&spi1>,"status";
+		spi2 = <&spi2>,"status";
+		i2c0 = <&i2c0>,"status";
+		i2c1 = <&i2c1>,"status";
+		i2c2 = <&i2c2>,"status";
+		i2c3 = <&i2c3>,"status";
+		i2c4 = <&i2c4>,"status";
+		i2c5 = <&i2c5>,"status";
+		i2s0 = <&i2s0>,"status";
+		i2s1 = <&i2s1>,"status";
+	};
 };


### PR DESCRIPTION
Summary:
    1. When setting device tree parameters with dtparam,
       you need to modify the module with __override__ in the device tree.