### PR TITLE
fb|iar: fix the case where running exit would hang.

### DIFF
--- a/drivers/misc/bt2hdmi-lt/hobot_lt8618sxb_config.c
+++ b/drivers/misc/bt2hdmi-lt/hobot_lt8618sxb_config.c
@@ -1968,21 +1968,6 @@ void Resolution_change(hobot_hdmi_sync_t* user_timing)
 			goto err0;
 		}	
 	}
-	//pr_info("%s hfp:%d,hs:%d,hbp:%d,hact:%d,htotal:%d,vfp:%d,vs:%d,vbp:%d,vact:%d,vtotal:%d,vic:%d,clk:%d\n",
-	// __func__,
-	// edid_timing.hfp,
-	// edid_timing.hs,
-	// edid_timing.hbp,
-	// edid_timing.hact,
-	// edid_timing.htotal,
-	// edid_timing.vfp,
-	// edid_timing.vs,
-	// edid_timing.vbp,
-	// edid_timing.vact,
-	// edid_timing.vtotal,
-	// edid_timing.vic,
-	// edid_timing.clk
-	// );
 
 	Format_Timing[18][0] =  edid_timing.hfp;
 	Format_Timing[18][1] =  edid_timing.hs;
@@ -2008,7 +1993,6 @@ void Resolution_change(hobot_hdmi_sync_t* user_timing)
 		Format_Timing[18][11] =  _4_3_;
     }
 	pixel_clk_mhz = edid_timing.clk / 1000000;
-	//pr_err("pixel clk:%d Mhz\n",pixel_clk_mhz);
 	if (pixel_clk_mhz > 100)		
 	{
 		Format_Timing[18][12] = _Greater_than_100M;

--- a/drivers/misc/bt2hdmi-lt/hobot_lt8618sxb_config.c
+++ b/drivers/misc/bt2hdmi-lt/hobot_lt8618sxb_config.c
@@ -1968,21 +1968,21 @@ void Resolution_change(hobot_hdmi_sync_t* user_timing)
 			goto err0;
 		}	
 	}
-	pr_info("%s hfp:%d,hs:%d,hbp:%d,hact:%d,htotal:%d,vfp:%d,vs:%d,vbp:%d,vact:%d,vtotal:%d,vic:%d,clk:%d\n",
-	__func__,
-	edid_timing.hfp,
-	edid_timing.hs,
-	edid_timing.hbp,
-	edid_timing.hact,
-	edid_timing.htotal,
-	edid_timing.vfp,
-	edid_timing.vs,
-	edid_timing.vbp,
-	edid_timing.vact,
-	edid_timing.vtotal,
-	edid_timing.vic,
-	edid_timing.clk
-	);
+	//pr_info("%s hfp:%d,hs:%d,hbp:%d,hact:%d,htotal:%d,vfp:%d,vs:%d,vbp:%d,vact:%d,vtotal:%d,vic:%d,clk:%d\n",
+	// __func__,
+	// edid_timing.hfp,
+	// edid_timing.hs,
+	// edid_timing.hbp,
+	// edid_timing.hact,
+	// edid_timing.htotal,
+	// edid_timing.vfp,
+	// edid_timing.vs,
+	// edid_timing.vbp,
+	// edid_timing.vact,
+	// edid_timing.vtotal,
+	// edid_timing.vic,
+	// edid_timing.clk
+	// );
 
 	Format_Timing[18][0] =  edid_timing.hfp;
 	Format_Timing[18][1] =  edid_timing.hs;
@@ -2008,7 +2008,7 @@ void Resolution_change(hobot_hdmi_sync_t* user_timing)
 		Format_Timing[18][11] =  _4_3_;
     }
 	pixel_clk_mhz = edid_timing.clk / 1000000;
-	pr_err("pixel clk:%d Mhz\n",pixel_clk_mhz);
+	//pr_err("pixel clk:%d Mhz\n",pixel_clk_mhz);
 	if (pixel_clk_mhz > 100)		
 	{
 		Format_Timing[18][12] = _Greater_than_100M;

--- a/drivers/soc/hobot/iar/hobot_iar.c
+++ b/drivers/soc/hobot/iar/hobot_iar.c
@@ -738,7 +738,6 @@ int disp_set_panel_timing(struct disp_timing *timing)
 	if (iar_pixel_clk_enable() != 0)
 		return -1;
 
-	//pr_err("disp set panel timing!!!!\n");
 	value = readl(g_iar_dev->regaddr + REG_IAR_PARAMETER_HTIM_FIELD1);
 	value = IAR_REG_SET_FILED(IAR_DPI_HBP_FIELD, timing->hbp, value);
 	value = IAR_REG_SET_FILED(IAR_DPI_HFP_FIELD, timing->hfp, value);
@@ -884,8 +883,6 @@ int32_t iar_channel_base_cfg(channel_base_cfg_t *cfg)
 		reg_overlay_opt_value & (0xffffffff & ~(1 << (channelid + 24)));
 	reg_overlay_opt_value =
 		reg_overlay_opt_value | (cfg->enable << (channelid + 24));
-	// pr_info("channel id is %d, enable is %d, reg value is 0x%x.\n",
-	// 		channelid, cfg->enable, reg_overlay_opt_value);
 
 	writel(reg_overlay_opt_value, g_iar_dev->regaddr + REG_IAR_OVERLAY_OPT);
 
@@ -3632,22 +3629,18 @@ int iar_get_output_mode(void){
 	reg_value = readl(g_iar_dev->regaddr + 0x340);
 	if (reg_value & 0x1)
 	{
-		//pr_info("Output: output mode is IPI\n");
 		ret = OUTPUT_IPI;
 	}
 	else if (reg_value & 0x2)
 	{
-		//pr_info("Output: output mode is BT1120\n");
 		ret = OUTPUT_BT1120;
 	}
 	else if (reg_value & 0x4)
 	{
-		//pr_info("Output: output mode is RGB\n");
 		ret = OUTPUT_RGB;
 	}
 	else if ((readl(g_iar_dev->regaddr + 0x800) & 0x13) == 0x13)
 	{
-		//pr_info("Output: output mode is MIPI-DSI\n");
 		ret = OUTPUT_MIPI_DSI;
 	}
 	if (disable_sif_mclk() != 0)

--- a/drivers/soc/hobot/iar/hobot_iar.c
+++ b/drivers/soc/hobot/iar/hobot_iar.c
@@ -738,7 +738,7 @@ int disp_set_panel_timing(struct disp_timing *timing)
 	if (iar_pixel_clk_enable() != 0)
 		return -1;
 
-	pr_err("disp set panel timing!!!!\n");
+	//pr_err("disp set panel timing!!!!\n");
 	value = readl(g_iar_dev->regaddr + REG_IAR_PARAMETER_HTIM_FIELD1);
 	value = IAR_REG_SET_FILED(IAR_DPI_HBP_FIELD, timing->hbp, value);
 	value = IAR_REG_SET_FILED(IAR_DPI_HFP_FIELD, timing->hfp, value);
@@ -884,8 +884,8 @@ int32_t iar_channel_base_cfg(channel_base_cfg_t *cfg)
 		reg_overlay_opt_value & (0xffffffff & ~(1 << (channelid + 24)));
 	reg_overlay_opt_value =
 		reg_overlay_opt_value | (cfg->enable << (channelid + 24));
-	pr_info("channel id is %d, enable is %d, reg value is 0x%x.\n",
-			channelid, cfg->enable, reg_overlay_opt_value);
+	// pr_info("channel id is %d, enable is %d, reg value is 0x%x.\n",
+	// 		channelid, cfg->enable, reg_overlay_opt_value);
 
 	writel(reg_overlay_opt_value, g_iar_dev->regaddr + REG_IAR_OVERLAY_OPT);
 
@@ -3632,22 +3632,22 @@ int iar_get_output_mode(void){
 	reg_value = readl(g_iar_dev->regaddr + 0x340);
 	if (reg_value & 0x1)
 	{
-		pr_info("Output: output mode is IPI\n");
+		//pr_info("Output: output mode is IPI\n");
 		ret = OUTPUT_IPI;
 	}
 	else if (reg_value & 0x2)
 	{
-		pr_info("Output: output mode is BT1120\n");
+		//pr_info("Output: output mode is BT1120\n");
 		ret = OUTPUT_BT1120;
 	}
 	else if (reg_value & 0x4)
 	{
-		pr_info("Output: output mode is RGB\n");
+		//pr_info("Output: output mode is RGB\n");
 		ret = OUTPUT_RGB;
 	}
 	else if ((readl(g_iar_dev->regaddr + 0x800) & 0x13) == 0x13)
 	{
-		pr_info("Output: output mode is MIPI-DSI\n");
+		//pr_info("Output: output mode is MIPI-DSI\n");
 		ret = OUTPUT_MIPI_DSI;
 	}
 	if (disable_sif_mclk() != 0)

--- a/drivers/video/fbdev/hobot_fb.c
+++ b/drivers/video/fbdev/hobot_fb.c
@@ -174,7 +174,7 @@ u8 dummy_edid[] = {
 
 static unsigned long get_line_length(int xres_virtual, int bpp)
 {
-	pr_err("%s: xr:%d,bpp:%d\n",__func__,xres_virtual,bpp);
+	//pr_err("%s: xr:%d,bpp:%d\n",__func__,xres_virtual,bpp);
 	//return (unsigned long)((((xres_virtual*bpp)+31)&~31) >> 3);
 	unsigned long length;
 	length = xres_virtual * bpp;
@@ -342,9 +342,9 @@ static int hbfb_check_var(struct fb_var_screeninfo *var, struct fb_info *info)
 	/*
 	 *  Memory limit
 	 */
-	line_length = get_line_length(var->xres_virtual, var->bits_per_pixel);
-	if (line_length * var->yres_virtual > MAX_FRAME_BUF_SIZE)
-		return -ENOMEM;
+	// line_length = get_line_length(var->xres_virtual, var->bits_per_pixel);
+	// if (line_length * var->yres_virtual > MAX_FRAME_BUF_SIZE)
+	// 	return -ENOMEM;
 
 	/*
 	 * Now that we checked it we alter var. The reason being is
@@ -615,6 +615,10 @@ static int hbfb_set_par(struct fb_info *info)
 	hobot_hdmi_sync_t hdmi_timing;
 	uint64_t iar_pixel_clk = 0;
 	extern channel_base_cfg_t store_chn_cfg;
+   
+	if (info->var.bits_per_pixel == 32) {
+		info->var.bits_per_pixel = 24;
+	}
 
 	user_config(1920,info->var.yres_virtual,info->var.xres,info->var.yres);
 	if(ubuntu_desktop == 0){
@@ -624,7 +628,7 @@ static int hbfb_set_par(struct fb_info *info)
 		info->fix.line_length = get_line_length(1920,24);
 		memcpy(&store_chn_cfg,&channel_base_cfg[0],sizeof(channel_base_cfg_t));
 	}
-	pr_err("%s: xv:%d,yv:%d,xr:%d,yr:%d\n",__func__,info->var.xres_virtual,info->var.yres_virtual,info->var.xres,info->var.yres);
+	//pr_err("%s: xv:%d,yv:%d,xr:%d,yr:%d\n",__func__,info->var.xres_virtual,info->var.yres_virtual,info->var.xres,info->var.yres);
 	iar_timing.hfp = info->var.right_margin;
 	iar_timing.hbp = info->var.left_margin;
 	iar_timing.vfp = info->var.lower_margin;

--- a/drivers/video/fbdev/hobot_fb.c
+++ b/drivers/video/fbdev/hobot_fb.c
@@ -174,8 +174,6 @@ u8 dummy_edid[] = {
 
 static unsigned long get_line_length(int xres_virtual, int bpp)
 {
-	//pr_err("%s: xr:%d,bpp:%d\n",__func__,xres_virtual,bpp);
-	//return (unsigned long)((((xres_virtual*bpp)+31)&~31) >> 3);
 	unsigned long length;
 	length = xres_virtual * bpp;
 	length = (length + 31) & ~31;
@@ -342,9 +340,6 @@ static int hbfb_check_var(struct fb_var_screeninfo *var, struct fb_info *info)
 	/*
 	 *  Memory limit
 	 */
-	// line_length = get_line_length(var->xres_virtual, var->bits_per_pixel);
-	// if (line_length * var->yres_virtual > MAX_FRAME_BUF_SIZE)
-	// 	return -ENOMEM;
 
 	/*
 	 * Now that we checked it we alter var. The reason being is
@@ -615,7 +610,6 @@ static int hbfb_set_par(struct fb_info *info)
 	hobot_hdmi_sync_t hdmi_timing;
 	uint64_t iar_pixel_clk = 0;
 	extern channel_base_cfg_t store_chn_cfg;
-   
 	if (info->var.bits_per_pixel == 32) {
 		info->var.bits_per_pixel = 24;
 	}
@@ -628,7 +622,6 @@ static int hbfb_set_par(struct fb_info *info)
 		info->fix.line_length = get_line_length(1920,24);
 		memcpy(&store_chn_cfg,&channel_base_cfg[0],sizeof(channel_base_cfg_t));
 	}
-	//pr_err("%s: xv:%d,yv:%d,xr:%d,yr:%d\n",__func__,info->var.xres_virtual,info->var.yres_virtual,info->var.xres,info->var.yres);
 	iar_timing.hfp = info->var.right_margin;
 	iar_timing.hbp = info->var.left_margin;
 	iar_timing.vfp = info->var.lower_margin;


### PR DESCRIPTION
Summary:
	1. Reduce the number of prints, which should effectively reduce execution time
	2. Convert all incoming bpp values ​​of 32 to 24